### PR TITLE
Refactor visualize

### DIFF
--- a/src/models/modelVisualizer.mc
+++ b/src/models/modelVisualizer.mc
@@ -135,8 +135,8 @@ let treeVisual = lam dot. lam model. lam v2str. lam displayNames. lam id.
     let edges = foldl (lam edges. lam e. strJoin "," [edges, e]) (head edges) (tail edges) in
     formatGraph dot vertices edges "tree" id
 
--- make all models into string object
-let visualize = lam models.
+-- format a model into a string representation for visualization
+let formatModels = lam models.
     let ids = mapi (lam i. lam x. i) models in
     let models = zipWith (lam x. lam y. (x,y)) models ids in
     let models = strJoin ",\n" (
@@ -156,8 +156,10 @@ let visualize = lam models.
             treeVisual dot btree node2str displayName id
         else error "unknown type") models
     ) in
-    print (foldl concat [] ["{\"models\": [\n", models, "]\n}\n"])
-                        
+    foldl concat [] ["{\"models\": [\n", models, "]\n}\n"]
+
+let visualize = compose print formatModels
+
 mexpr
 let states = [1,2,3] in
 let transitions = [(1,2,'0'),(3,1,'0'),(1,2,'1'),(2,3,'1'),(1,2,'2'),(3,1,'1')] in

--- a/src/models/modelVisualizer.mc
+++ b/src/models/modelVisualizer.mc
@@ -136,27 +136,25 @@ let treeVisual = lam dot. lam model. lam v2str. lam displayNames. lam id.
     formatGraph dot vertices edges "tree" id
 
 -- format a model into a string representation for visualization
+let formatModel = lam model. lam id.
+    let dot = modelGetDot model id [] in
+    match model with Digraph(digraph,vertex2str,edge2str,direction,displayNames) then
+        graphVisual dot digraph displayNames vertex2str edge2str "digraph" id
+    else match model with DFA(dfa,input,state2str,label2str,direction,displayNames) then
+        dfaVisual dot dfa input state2str label2str "dfa" displayNames id
+    else match model with Graph(graph,vertex2str,edge2str,direction,displayNames) then
+        graphVisual dot graph displayNames vertex2str edge2str "graph" id
+    else match model with NFA(nfa,input,state2str,label2str,direction,displayNames) then
+        nfaVisual dot nfa input state2str label2str "nfa" displayNames id
+    else match model with BTree(btree,node2str,direction,displayName) then
+        treeVisual dot btree node2str displayName id
+    else error "Unknown model type"
+
+-- format a list of models into a string representation for visualization
 let formatModels = lam models.
-    let ids = mapi (lam i. lam x. i) models in
-    let models = zipWith (lam x. lam y. (x,y)) models ids in
-    let models = strJoin ",\n" (
-        map (lam model_tup.
-	    let model = model_tup.0 in
-	    let id = model_tup.1 in
-        let dot = modelGetDot model id [] in
-	    match model with Digraph(digraph,vertex2str,edge2str,direction,displayNames) then
-            graphVisual dot digraph displayNames vertex2str edge2str "digraph" id
-        else match model with DFA(dfa,input,state2str,label2str,direction,displayNames) then
-            dfaVisual dot dfa input state2str label2str "dfa" displayNames id
-        else match model with Graph(graph,vertex2str,edge2str,direction,displayNames) then
-            graphVisual dot graph displayNames vertex2str edge2str "graph" id
-        else match model with NFA(nfa,input,state2str,label2str,direction,displayNames) then
-            nfaVisual dot nfa input state2str label2str "nfa" displayNames id
-        else match model with BTree(btree, node2str,direction,displayName) then
-            treeVisual dot btree node2str displayName id
-        else error "unknown type") models
-    ) in
-    foldl concat [] ["{\"models\": [\n", models, "]\n}\n"]
+    let ids = mapi const models in
+    let formattedModels = zipWith formatModel models ids in
+    join ["{\"models\": [\n", strJoin ",\n" formattedModels, "]\n}\n"]
 
 let visualize = compose print formatModels
 


### PR DESCRIPTION
This pull request refactors the `visualize` function and introduces a `formatModels` function which produces a string representation of a list of models (instead of printing it like `visualize`)