### PR TITLE
Quick-fix for new-client/refresh

### DIFF
--- a/src/ocaml-server/main.ml
+++ b/src/ocaml-server/main.ml
@@ -39,6 +39,7 @@ let serve ~docroot ~index uri path =
       match stat.Unix.st_kind with
       | S_DIR ->
          begin
+           modified := true;
            let uri = Uri.with_path uri (String.concat ""[path; index]) in
            serve_file ~docroot ~uri
          end

--- a/src/webpage/js/app.js
+++ b/src/webpage/js/app.js
@@ -5,7 +5,6 @@ function render() {
     ws.onmessage = function(x) {
 	let data_models = JSON.parse(x.data);
 	if (data_models.models) {
-
 	    document.getElementById("app").innerHTML = "";
 		const root = document.body.querySelector("#app");
 		// Maps over all models in the generated output.
@@ -31,12 +30,10 @@ function render() {
 			break;
 		    }
 		})
-	    } else {
-		document.getElementById("error-container").textContent += data_models;
-	    }
-	};
-
-    
+	} else {
+	    document.getElementById("error-container").textContent += data_models;
+	};   
+    }
 }
 
 render()


### PR DESCRIPTION
The web-socket would not have sent the data if a new client connects or the page refreshes, which was really bad. It would only send the data if the source file was updated. Now, when a client asks for index.html, the websocket also sends the data-source!