### PR TITLE
Update identifiers which were renamed in the Miking standard library

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,9 +122,9 @@ The constructor for the DFA takes in seven arguments:
 
 6. **eqv** and 7. **eql** There are no data type requirements, thus you would need to write equality functions for the states (eqv) and the labels (eql). The equality functions take two inputs and returns either **true** if they are equal or **false** if they are not. Ex :
 
-    `let eqv = eqstr`
+    `let eqv = eqString`
 
-	`let eql = eqchar`
+	`let eql = eqChar`
 
 	`let settings = [("s0",[("label","start state")]),("s3",[("label","accept state")])]`
 
@@ -153,7 +153,7 @@ A directed graph contains three different variables:
 
 2. **eqv** and 3. **eql:** There are no data type requirements, thus you would need to write equality functions for the nodes (eqv) and the labels (eql). The equality functions take two inputs and returns either **true** if they are equal or **false** if they are not. Ex:
 
-    `let eqv = eqchar`
+    `let eqv = eqChar`
 
     `let eql = eqi`
 
@@ -353,7 +353,7 @@ There is a **examples** folder in the root of the project which contains some fi
 	let startState = "s0" in
 	let acceptStates = ["s3"] in
 
-	let dfa = dfaConstr states transitions startState acceptStates eqstr eqchar in
+	let dfa = dfaConstr states transitions startState acceptStates eqString eqChar in
 
 	visualize [
 		-- accepted by the DFA
@@ -384,13 +384,13 @@ This program displays a digraph and a graph on the same page.
 
 	-- create your directed graph
 	let digraph = foldr (lam e. lam g. digraphAddEdge e.0 e.1 e.2 g) 
-	(foldr digraphAddVertex (digraphEmpty eqchar eqi) ['A','B','C','D','E']) 
+	(foldr digraphAddVertex (digraphEmpty eqChar eqi) ['A','B','C','D','E']) 
                 [('A','B',2),('A','C',5),('B','C',2),('B','D',4),('C','D',5),('C','E',5),('E','D',2)] in
 
 
 	-- create your graph
 	let graph = foldr (lam e. lam g. graphAddEdge e.0 e.1 e.2 g) 
-	(foldr graphAddVertex (graphEmpty eqi eqstr) [1,2,3,4]) [(1,2,""),(3,2,""),(1,3,""),(3,4,"")] in
+	(foldr graphAddVertex (graphEmpty eqi eqString) [1,2,3,4]) [(1,2,""),(3,2,""),(1,3,""),(3,4,"")] in
 
 	visualize [
 		Digraph(digraph, char2string,int2string,"LR",[]),
@@ -412,7 +412,7 @@ This program creates both a NFA and a Binary tree and displays them.
 	let nfaAcceptStates = ["a"] in
 	
 	-- create your NFA
-	let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqstr eqchar in
+	let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqString eqChar in
 
 
 	-- create your Binary Tree
@@ -435,7 +435,7 @@ The following code creates a directed graph and prints it as dot code. To do the
 
 	-- create your directed graph
 	let digraph = foldr (lam e. lam g. digraphAddEdge e.0 e.1 e.2 g) 
-	(foldr digraphAddVertex (digraphEmpty eqchar eqi) ['A','B','C','D','E']) 
+	(foldr digraphAddVertex (digraphEmpty eqChar eqi) ['A','B','C','D','E']) 
                 [('A','B',2),('A','C',5),('B','C',2),('B','D',4),('C','D',5),('C','E',5),('E','D',2)] in
   
 	let digraphModel = Digraph(digraph, char2string,int2string,"LR",[]) in

--- a/examples/dfa.mc
+++ b/examples/dfa.mc
@@ -24,7 +24,7 @@ let startState = "s0" in
 let acceptStates = ["s3"] in
 
 -- constructing the DFA
-let dfa = dfaConstr states transitions startState acceptStates eqstr eqchar in
+let dfa = dfaConstr states transitions startState acceptStates eqString eqChar in
 
 -- The input for simulation is given here as the second argument
 -- in the constructor.

--- a/examples/digraph.mc
+++ b/examples/digraph.mc
@@ -10,7 +10,7 @@ mexpr
 let char2string = (lam b. [b]) in
 
 -- create an empty digraph
-let digraph = digraphEmpty eqchar eqi in
+let digraph = digraphEmpty eqChar eqi in
 
 -- adding vertices to the digraph
 let digraph = foldr digraphAddVertex digraph ['A','B','C','D','E'] in

--- a/examples/graph.mc
+++ b/examples/graph.mc
@@ -10,7 +10,7 @@ mexpr
 let string2string = (lam b. b) in
 
 -- create an empty graph, specify the equality functions for both the vertices and the edge's labels
-let graph = graphEmpty eqi eqstr in
+let graph = graphEmpty eqi eqString in
 
 -- adding vertices to the graph
 let graph = foldr graphAddVertex graph [1,2,3,4] in

--- a/examples/nfa-no-simulation.mc
+++ b/examples/nfa-no-simulation.mc
@@ -17,7 +17,7 @@ let nfaStartState = "a" in
 let nfaAcceptStates = ["a"] in
 
 -- constructing the NFA
-let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqstr eqchar in
+let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqString eqChar in
 
 -- The input for simulation is given here as the second argument
 -- in the constructor.

--- a/examples/nfa.mc
+++ b/examples/nfa.mc
@@ -17,7 +17,7 @@ let nfaStartState = "a" in
 let nfaAcceptStates = ["a"] in
 
 -- constructing the NFA
-let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqstr eqchar in
+let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqString eqChar in
 
 -- The input for simulation is given here as the second argument
 -- in the constructor.

--- a/src/models/model.mc
+++ b/src/models/model.mc
@@ -17,7 +17,7 @@ let states = ["a","b","c"] in
 let transitions = [("a","b",'1'),("b","c",'0'),("c","a",'1')] in
 let startState = "a" in
 let acceptStates = ["a", "c"] in
-let dfa = dfaConstr states transitions startState acceptStates eqstr eqchar in
+let dfa = dfaConstr states transitions startState acceptStates eqString eqChar in
 let model = DFA(dfa, "1011", lam b. b, lam b. [b],"LR",[]) in 
 utest match model with DFA(d,i,s2s,t2s,"LR",[]) then i else "" with "1011" in
 utest match model with DFA(d,i,s2s,t2s,"LR",[]) then d.acceptStates else "" with ([(['a']),(['c'])]) in 

--- a/src/models/modelDot.mc
+++ b/src/models/modelDot.mc
@@ -78,7 +78,7 @@ let btreeGetDot = lam tree. lam node2str. lam id. lam direction. lam vSettings.
 
 -- returns a graph in dot.
 let graphGetDot = lam graph. lam v2str. lam l2str. lam id. lam direction. lam graphType. lam vSettings.
-    let delimiter = if (eqstr graphType "graph") then "--" else "->" in
+    let delimiter = if (eqString graphType "graph") then "--" else "->" in
     let dotVertices = map (lam v. 
         let extra = find (lam x. graph.eqv x.0 v) vSettings in
         let settings = concat (match extra with Some e then (settingsToDot e.1 id) else "") "" in

--- a/src/models/types/circuit/circCompDot.mc
+++ b/src/models/types/circuit/circCompDot.mc
@@ -91,7 +91,7 @@ let circOtherToDot = lam quote. lam name. lam value. lam _. lam custom_settings.
 let componentToDot = lam comp. lam quote. lam fig_settings.
     match comp with Component (comp_type,name,maybe_value,isConnected) then
         let figure_setting = 
-            let fig = find (lam x. eqstr x.0 comp_type) fig_settings in
+            let fig = find (lam x. eqString x.0 comp_type) fig_settings in
             match fig with Some (_,setting,unit) then Some (setting,unit) else None() in
         -- round to integer
         let value_str = match maybe_value with Some v then int2string (roundfi v) else "" in

--- a/test/test-conv-to-pdf.mc
+++ b/test/test-conv-to-pdf.mc
@@ -15,14 +15,14 @@ let transitions = [
 let startState = "s0" in
 let acceptStates = ["s2"] in
 
-let dfa = dfaConstr states transitions startState acceptStates eqstr eqchar in
+let dfa = dfaConstr states transitions startState acceptStates eqString eqChar in
 let myDfa = DFA(dfa, "101", string2string, char2string,"LR",[]) in
 
 let digraph = foldr (lam e. lam g. digraphAddEdge e.0 e.1 e.2 g) 
-                (foldr digraphAddVertex (digraphEmpty eqchar eqi) ['A','B','C','D','E','F']) 
+                (foldr digraphAddVertex (digraphEmpty eqChar eqi) ['A','B','C','D','E','F']) 
                 [('A','B',2),('A','C',5),('B','C',2),('B','D',4),('C','D',5),('C','E',5)] in
 let graph = foldr (lam e. lam g. graphAddEdge e.0 e.1 e.2 g) 
-              (foldr graphAddVertex (graphEmpty eqi eqstr) [1,2,3,4]) 
+              (foldr graphAddVertex (graphEmpty eqi eqString) [1,2,3,4]) 
               [(1,2,"g"),(3,2,"a"),(1,3,""),(3,4,"")] in
 
 let treeModel = Node(2, Node(3, Nil (), Leaf 4), Leaf 5) in
@@ -33,7 +33,7 @@ let nfaStates = ["a","b","c","d","e","f"] in
 let nfaTransitions = [("a","b",'1'),("b","c",'0'),("c","d",'2'),("c","e",'2'),("d","a",'1'),("e","f",'1')] in
 let nfaStartState = "a" in
 let nfaAcceptStates = ["a"] in
-let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqStr eqchar in
+let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqString eqChar in
 let myNfa = NFA(nfa, "102", string2string, char2string,"LR",[]) in
 
 

--- a/test/test.mc
+++ b/test/test.mc
@@ -19,16 +19,16 @@ let transitions = [
 let startState = "s0" in
 let acceptStates = ["s3"] in
 
-let dfa = dfaConstr states transitions startState acceptStates eqstr eqchar in
+let dfa = dfaConstr states transitions startState acceptStates eqString eqChar in
 
 -- create your directed graph
 let digraph = foldr (lam e. lam g. digraphAddEdge e.0 e.1 e.2 g) 
-(foldr digraphAddVertex (digraphEmpty eqchar eqi) ['A','B','C','D','E']) 
+(foldr digraphAddVertex (digraphEmpty eqChar eqi) ['A','B','C','D','E']) 
             [('A','B',2),('A','C',5),('B','C',2),('B','D',4),('C','D',5),('C','E',5),('E','D',2)] in
 
 -- create your graph
 let graph = foldr (lam e. lam g. graphAddEdge e.0 e.1 e.2 g) 
-(foldr graphAddVertex (graphEmpty eqi eqstr) [1,2,3,4]) [(1,2,""),(3,2,""),(1,3,""),(3,4,"")] in
+(foldr graphAddVertex (graphEmpty eqi eqString) [1,2,3,4]) [(1,2,""),(3,2,""),(1,3,""),(3,4,"")] in
 
 let nfaStates = ["a","b","c","d","e","f"] in
 let nfaTransitions = [("a","b",'1'),("b","c",'0'),("c","d",'2'),("c","e",'2'),("d","a",'1'),("e","f",'1')] in
@@ -37,7 +37,7 @@ let nfaAcceptStates = ["a"] in
 	
 
 -- create your NFA
-let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqstr eqchar in
+let nfa = nfaConstr nfaStates nfaTransitions nfaStartState nfaAcceptStates eqString eqChar in
 
 -- create your BTree
 let btree = btreeConstr (Node(2, Node(3, Nil (), Leaf 4), Leaf 5)) eqi in


### PR DESCRIPTION
https://github.com/miking-lang/miking/pull/189 renamed some functions in the standard library, this PR updates miking-ipm with these changes.

Best as I can tell the changes are:

```
CEqs      -> CEqsym
Ceqs      -> Ceqsym
eq        -> eqExpr
eqchar    -> eqChar
eqs       -> eqsym
eqstr     -> eqString
geqchar   -> geqChar
leqchar   -> leqChar
show_char -> showChar
symbolize -> symbolizeExpr
```

I also found one instance of `eqStr` here, which I changed to `eqString`.